### PR TITLE
Added TX deadband from NotFastEnuf acro only fork and idle up switch

### DIFF
--- a/Silverware/acro_only/control_acro_only.c
+++ b/Silverware/acro_only/control_acro_only.c
@@ -115,6 +115,18 @@ float rate_multiplier = 1.0;
 		#else
 		rxcopy[i] = rx[i] * rate_multiplier;
 		#endif
+
+		#ifdef STICKS_DEADBAND
+		if ( fabsf( rxcopy[ i ] ) <= STICKS_DEADBAND ) {
+			rxcopy[ i ] = 0.0f;
+		} else {
+			if ( rxcopy[ i ] >= 0 ) {
+				rxcopy[ i ] = mapf( rxcopy[ i ], STICKS_DEADBAND, 1, 0, 1 );
+			} else {
+				rxcopy[ i ] = mapf( rxcopy[ i ], -STICKS_DEADBAND, -1, 0, -1 );
+			}
+		}
+		#endif
 	}
 
 
@@ -231,10 +243,15 @@ pid_precalc();
 
 float	throttle;
 
+#ifndef IDLE_UP
 // map throttle so under 10% it is zero	
 if ( rx[3] < 0.1f ) throttle = 0;
 else throttle = (rx[3] - 0.1f)*1.11111111f;
-
+#else
+// check if IDLE_UP switch is on
+if (!aux[IDLE_UP]) throttle = 0;
+else throttle =  (float) IDLE_THR + rx[3] * (1.0f - (float) IDLE_THR);
+#endif
 
 // turn motors off if throttle is off and pitch / roll sticks are centered
 	if ( failsafe || (throttle < 0.001f && (!ENABLESTIX || !onground_long || (fabsf(rx[ROLL]) < (float) ENABLESTIX_TRESHOLD && fabsf(rx[PITCH]) < (float) ENABLESTIX_TRESHOLD && fabsf(rx[YAW]) < (float) ENABLESTIX_TRESHOLD ) ) ) ) 

--- a/Silverware/acro_only/pid_acro_only.c
+++ b/Silverware/acro_only/pid_acro_only.c
@@ -47,7 +47,7 @@ THE SOFTWARE.
 
 //      	                  ROLL       PITCH     YAW
 float pidkp[PIDNUMBER] = { 16.0e-2 , 16.0e-2 , 5e-1 }; 
-float pidki[PIDNUMBER] = { 12.0e-1 , 12.0e-1 , 30e-1 };	
+float pidki[PIDNUMBER] = { 12.0e-1 , 12.0e-1 , 3e-1 };	
 float pidkd[PIDNUMBER] = { 8.0e-1 , 8.0e-1 , 0e-1 };
 
 


### PR DESCRIPTION
Added TX deadband from NotFastEnuf acro only fork, and idle up switch.
TX deadband example configuration in config.h:
// NotFastEnuf Note:  a deadband has been added for transmitter sticks that don't perfectly center - this value equates to a percentage of stick travel
// for example .01f is 1% of stick range - comment out to disable if not needed
#define STICKS_DEADBAND .01f

Idle up works like so:
- when switch is in OFF (0) position, throttle is set to 0 regardless of the throttle stick position.
- when switch is in ON (1) position, throttle is scaled linearly from IDLE_THR to 1, so stick deflection at 0 is now IDLE_THR.

Allows for more throttle resolution versus idle up configuration in the transmitter.

Example configuration in config.h:
//Idle up switch, comment out if not needed
#define IDLE_UP DEVO_CHAN_5
#define IDLE_THR 0.05f //5% of throttle stick travel
